### PR TITLE
adding minimum stub for tdqm with doc string.

### DIFF
--- a/tqdm/__init__.pyi
+++ b/tqdm/__init__.pyi
@@ -1,0 +1,121 @@
+from io import StringIO, TextIOWrapper
+from typing import Any, Iterable, Iterator, Mapping, Optional, Text, Tuple, TypeVar, Generic, Union
+
+_T = TypeVar("_T")
+
+class tqdm(Iterator[_T], Generic[_T]):
+    def __init__(self, iterable: Optional[Iterable[_T]], desc: Optional[Text] = ..., total:Optional[float] = ..., leave: Optional[bool] = ..., file: Optional[Union[TextIOWrapper, StringIO]] = ..., ncols: Optional[int] = ..., mininterval: Optional[float] = ..., maxinterval: Optional[float] = ..., miniters: Optional[float] = ..., ascii: Optional[Union[bool, Text]] = ..., disable: Optional[bool] = ..., unit: Optional[Text] = ..., unit_scale: Optional[Union[bool, int, float]] = ..., dynamic_ncols: Optional[bool] = ..., smoothing: Optional[float] = ..., bar_format: Optional[Text] = ..., initial: Optional[float] = ..., position: Optional[int] = ..., postfix: Optional[Mapping[Text, Any]]=..., unit_divisor: Optional[float] = ..., write_bytes: Optional[bool] = ..., lock_args:Tuple[Any, ...]=..., nrows: Optional[int] = ..., gui: Optional[bool] = ..., **kwargs: Any) -> None:
+         """
+        Parameters
+        ----------
+        iterable  : iterable, optional
+            Iterable to decorate with a progressbar.
+            Leave blank to manually manage the updates.
+        desc  : str, optional
+            Prefix for the progressbar.
+        total  : int or float, optional
+            The number of expected iterations. If unspecified,
+            len(iterable) is used if possible. If float("inf") or as a last
+            resort, only basic progress statistics are displayed
+            (no ETA, no progressbar).
+            If `gui` is True and this parameter needs subsequent updating,
+            specify an initial arbitrary large positive number,
+            e.g. 9e9.
+        leave  : bool, optional
+            If [default: True], keeps all traces of the progressbar
+            upon termination of iteration.
+            If `None`, will leave only if `position` is `0`.
+        file  : `io.TextIOWrapper` or `io.StringIO`, optional
+            Specifies where to output the progress messages
+            (default: sys.stderr). Uses `file.write(str)` and `file.flush()`
+            methods.  For encoding, see `write_bytes`.
+        ncols  : int, optional
+            The width of the entire output message. If specified,
+            dynamically resizes the progressbar to stay within this bound.
+            If unspecified, attempts to use environment width. The
+            fallback is a meter width of 10 and no limit for the counter and
+            statistics. If 0, will not print any meter (only stats).
+        mininterval  : float, optional
+            Minimum progress display update interval [default: 0.1] seconds.
+        maxinterval  : float, optional
+            Maximum progress display update interval [default: 10] seconds.
+            Automatically adjusts `miniters` to correspond to `mininterval`
+            after long display update lag. Only works if `dynamic_miniters`
+            or monitor thread is enabled.
+        miniters  : int or float, optional
+            Minimum progress display update interval, in iterations.
+            If 0 and `dynamic_miniters`, will automatically adjust to equal
+            `mininterval` (more CPU efficient, good for tight loops).
+            If > 0, will skip display of specified number of iterations.
+            Tweak this and `mininterval` to get very efficient loops.
+            If your progress is erratic with both fast and slow iterations
+            (network, skipping items, etc) you should set miniters=1.
+        ascii  : bool or str, optional
+            If unspecified or False, use unicode (smooth blocks) to fill
+            the meter. The fallback is to use ASCII characters " 123456789#".
+        disable  : bool, optional
+            Whether to disable the entire progressbar wrapper
+            [default: False]. If set to None, disable on non-TTY.
+        unit  : str, optional
+            String that will be used to define the unit of each iteration
+            [default: it].
+        unit_scale  : bool or int or float, optional
+            If 1 or True, the number of iterations will be reduced/scaled
+            automatically and a metric prefix following the
+            International System of Units standard will be added
+            (kilo, mega, etc.) [default: False]. If any other non-zero
+            number, will scale `total` and `n`.
+        dynamic_ncols  : bool, optional
+            If set, constantly alters `ncols` and `nrows` to the
+            environment (allowing for window resizes) [default: False].
+        smoothing  : float, optional
+            Exponential moving average smoothing factor for speed estimates
+            (ignored in GUI mode). Ranges from 0 (average speed) to 1
+            (current/instantaneous speed) [default: 0.3].
+        bar_format  : str, optional
+            Specify a custom bar string formatting. May impact performance.
+            [default: '{l_bar}{bar}{r_bar}'], where
+            l_bar='{desc}: {percentage:3.0f}%|' and
+            r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, '
+              '{rate_fmt}{postfix}]'
+            Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt,
+              percentage, elapsed, elapsed_s, ncols, nrows, desc, unit,
+              rate, rate_fmt, rate_noinv, rate_noinv_fmt,
+              rate_inv, rate_inv_fmt, postfix, unit_divisor,
+              remaining, remaining_s.
+            Note that a trailing ": " is automatically removed after {desc}
+            if the latter is empty.
+        initial  : int or float, optional
+            The initial counter value. Useful when restarting a progress
+            bar [default: 0]. If using float, consider specifying `{n:.3f}`
+            or similar in `bar_format`, or specifying `unit_scale`.
+        position  : int, optional
+            Specify the line offset to print this bar (starting from 0)
+            Automatic if unspecified.
+            Useful to manage multiple bars at once (eg, from threads).
+        postfix  : dict or *, optional
+            Specify additional stats to display at the end of the bar.
+            Calls `set_postfix(**postfix)` if possible (dict).
+        unit_divisor  : float, optional
+            [default: 1000], ignored unless `unit_scale` is True.
+        write_bytes  : bool, optional
+            If (default: None) and `file` is unspecified,
+            bytes will be written in Python 2. If `True` will also write
+            bytes. In all other cases will default to unicode.
+        lock_args  : tuple, optional
+            Passed to `refresh` for intermediate output
+            (initialisation, iterating, and updating).
+        nrows  : int, optional
+            The screen height. If specified, hides nested bars outside this
+            bound. If unspecified, attempts to use environment height.
+            The fallback is 20.
+        gui  : bool, optional
+            WARNING: internal parameter - do not use.
+            Use tqdm.gui.tqdm(...) instead. If set, will attempt to use
+            matplotlib animations for a graphical output [default: False].
+
+        Returns
+        -------
+        out  : decorated iterator.
+        """
+        ...


### PR DESCRIPTION
- simplified stub and moved it to __init__.py
- added doc string.

source
https://github.com/tqdm/tqdm

docs
https://tqdm.github.io/


common usage of tdqm

```
from tqdm import tqdm
from time import sleep

for i in tqdm(range(20)):
    sleep(0.25)
    print(i)
```