### PR TITLE
Fix mapper-based calling convention of DataFrame rename

### DIFF
--- a/pandas/core/frame.pyi
+++ b/pandas/core/frame.pyi
@@ -248,7 +248,6 @@ class DataFrame(NDFrame):
     @overload
     def rename(
         self,
-        index: Optional[Union[Dict[Union[_str, int], _str], Callable]] = ...,
         mapper: Optional[Callable],
         axis: Optional[AxisType] = ...,
         copy: _bool = ...,


### PR DESCRIPTION
When specifying `mapper`, you can't specify `index`.