### PR TITLE
fix series.astype dtype argument for pandas

### DIFF
--- a/pandas/core/series.pyi
+++ b/pandas/core/series.pyi
@@ -431,7 +431,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     ) -> Series[S1]: ...
     def astype(
         self,
-        dtype: Union[S1, _str],
+        dtype: Union[S1, _str, Type[Scalar]],
         copy: _bool = ...,
         errors: Union[_str, Literal["raise", "ignore"]] = ...,
     ) -> Series: ...


### PR DESCRIPTION
With pylance 2021.5.3, the following code
```python
import pandas as pd

df = pd.DataFrame({"x": [1.0, 2.0, 3.0], "y": [4.0, 5, 6]})

sx: pd.Series = df["x"]

ss = sx.astype(str)

print(ss)
```
reports on the `astype` line:
```
Argument of type "Type[str]" cannot be assigned to parameter "dtype" of type "Dtype@__getitem__ | str" in function "astype"
  Type "Type[str]" cannot be assigned to type "Dtype@__getitem__ | str"
    Type "Type[str]" cannot be assigned to type "Dtype@__getitem__"
    "Type[type]" is incompatible with "_str"
```
This PR fixes that issue.


