### PR TITLE
pandas:  fix series name argument

### DIFF
--- a/pandas/core/series.pyi
+++ b/pandas/core/series.pyi
@@ -56,7 +56,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         data: Optional[Union[_ListLike, Series[S1], Dict[int, S1], Dict[_str, S1]]] = ...,
         index: Union[_str, int, Series, List, Index] = ...,
         dtype = ...,
-        name: _str = ...,
+        name: Optional[Hashable] = ...,
         copy: bool = ...,
         fastpath: bool = ...
     ): ...


### PR DESCRIPTION
pyright 2021.5.3

The following simple code reports an error:

```python
import pandas as pd

s = pd.Series([1, 2, 3], name="hey")

t = pd.Series([1, 2, 3], name=s.name)
```

Error is:
```
Argument of type "Hashable | None" cannot be assigned to parameter "name" of type "_str" in function "__init__"
  Type "Hashable | None" cannot be assigned to type "_str"
    "Hashable" is incompatible with "str"
    Type "None" cannot be assigned to type "_str"
```

This PR fixes this by changing the argument type for `name` in `Series` to be `Optional[Hashable]`