### PR TITLE
Fix a syntax error in the matplotlib stubs

### DIFF
--- a/matplotlib/axes/_axes.pyi
+++ b/matplotlib/axes/_axes.pyi
@@ -401,8 +401,9 @@ class Axes(_AxesBase):
     have_units: Any  # TODO
 
     def hexbin(
-        self
-        x: ArrayLike, y: ArrayLike,
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
         C: Optional[ArrayLike] = ...,
         gridsize: Union[int, Tuple[int, int]] = ...,
         bins: Optional[Union[Literal["log"], int, Sequence[Any]]] = ...,

--- a/matplotlib/image.pyi
+++ b/matplotlib/image.pyi
@@ -7,7 +7,7 @@ from PIL.Image import Image as PILImage
 
 from matplotlib._typing import ArrayLike, ndarray
 from matplotlib.artist import Artist
-from matplotlib.axes import Axes
+from matplotlib.axes._axes import Axes
 from matplotlib.backend_bases import LocationEvent, MouseEvent, RendererBase
 from matplotlib.cm import Colormap, ScalarMappable
 from matplotlib.colors import Normalize


### PR DESCRIPTION
There was a comma missing after `self`.

Also, my type checker had problems with circular imports in `matplotlib/image.pyi` which I was able to solve by making the import more specific. I can remove that change if you'd prefer that.