### PR TITLE
Allow a scalar argument for data in Series

### DIFF
--- a/pandas/core/series.pyi
+++ b/pandas/core/series.pyi
@@ -53,7 +53,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     _ListLike = Union[np.ndarray, Dict[_str, np.ndarray], Sequence, Index]
     def __init__(
         self,
-        data: Optional[Union[_ListLike, Series[S1], Dict[int, S1], Dict[_str, S1]]] = ...,
+        data: Optional[Union[object, _ListLike, Series[S1], Dict[int, S1], Dict[_str, S1]]] = ...,
         index: Union[_str, int, Series, List, Index] = ...,
         dtype = ...,
         name: Optional[Hashable] = ...,


### PR DESCRIPTION
pylance 2021.6.3

This simple code 
```python
import pandas as pd

s = pd.Series(4)
```
produces the error:
```
Argument of type "Literal[4]" cannot be assigned to parameter "data" of type "ndarray | Dict[_str, ndarray] | Sequence[Unknown] | Index[Unknown] | Series[S1@Series] | Dict[int, S1@Series] | Dict[_str, S1@Series] | None" in function "__init__"
  Type "Literal[4]" cannot be assigned to type "ndarray | Dict[_str, ndarray] | Sequence[Unknown] | Index[Unknown] | Series[S1@Series] | Dict[int, S1@Series] | Dict[_str, S1@Series] | None"
    "Literal[4]" is incompatible with "ndarray"
    "Literal[4]" is incompatible with "Dict[_str, ndarray]"
    "Literal[4]" is incompatible with "Sequence[Unknown]"
    "Literal[4]" is incompatible with "Index[Unknown]"
    "Literal[4]" is incompatible with "Series[S1@Series]"
    "Literal[4]" is incompatible with "Dict[int, S1@Series]"
    "Literal[4]" is incompatible with "Dict[_str, S1@Series]"
```

This PR fixes that.

Note that any object can be passed as a singleton to create a series, so I'm allowing that, although it doesn't seem great from a typing perspective.
