### PR TITLE
pandas: allow scalars as args to series.fillna

### DIFF
--- a/pandas/core/series.pyi
+++ b/pandas/core/series.pyi
@@ -323,7 +323,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def fillna(
         self,
-        value: Union[S1, Dict, Series[S1], DataFrame],
+        value: Union[Scalar, Dict, Series[S1], DataFrame],
         method: Optional[Union[_str, Literal["backfill", "bfill", "pad", "ffill"]]] = ...,
         axis: SeriesAxisType = ...,
         limit: Optional[int] = ...,
@@ -334,7 +334,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def fillna(
         self,
-        value: Union[S1, Dict, Series[S1], DataFrame],
+        value: Union[Scalar, Dict, Series[S1], DataFrame],
         method: Optional[Union[_str, Literal["backfill", "bfill", "pad", "ffill"]]] = ...,
         axis: SeriesAxisType = ...,
         *,
@@ -344,7 +344,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def fillna(
         self,
-        value: Union[S1, Dict, Series[S1], DataFrame],
+        value: Union[Scalar, Dict, Series[S1], DataFrame],
         method: Optional[Union[_str, Literal["backfill", "bfill", "pad", "ffill"]]] = ...,
         axis: SeriesAxisType = ...,
         inplace: _bool = ...,


### PR DESCRIPTION
pylance 2021.7.3

Following code:
```python
import pandas as pd
import numpy as np

df: pd.DataFrame = pd.DataFrame({"x": [1, np.nan, 3]})

df["x"].fillna(1234)
```
produces
```
No overloads for "fillna" match the provided arguments
  Argument types: (Literal[1234])
```

This PR fixes that issue.  

