### PR TITLE
allow Index in setitem on DataFrame

### DIFF
--- a/pandas/core/frame.pyi
+++ b/pandas/core/frame.pyi
@@ -69,7 +69,7 @@ class _LocIndexerFrame(_LocIndexer):
 
     def __setitem__(
         self,
-        idx: Union[MaskType, StrLike, Tuple[Union[MaskType, List[str]], Union[MaskType, List[str], str]],],
+        idx: Union[MaskType, StrLike, Tuple[Union[MaskType, Index, List[str]], Union[MaskType, List[str], str]],],
         value: Union[float, _np.ndarray, Series[Dtype], DataFrame],
     ) -> None: ...
 


### PR DESCRIPTION
pylance 2021.7.5

The following code:
```python
import pandas as pd

df = pd.DataFrame(
    [[1, 10], [2, 20], [3, 30]], columns=["one", "ten"], index=["a", "b", "c"]
)

i = pd.Index(["a", "c"])

df.loc[i, "ten"] = 100
```
produces
```
Argument of type "tuple[Index[str], str]" cannot be assigned to parameter "idx" of type "Series[bool] | np_ndarray_bool | Sequence[bool] | str | str_ | Tuple[Series[bool] | np_ndarray_bool | Sequence[bool] | slice | np_ndarray_int64 | Index[int] | List[int] | Series[int] | List[str], Series[bool] | np_ndarray_bool | Sequence[bool] | List[str] | str | str_]" in function "__setitem__"
  Type "tuple[Index[str], str]" cannot be assigned to type "Series[bool] | np_ndarray_bool | Sequence[bool] | str | str_ | Tuple[Series[bool] | np_ndarray_bool | Sequence[bool] | slice | np_ndarray_int64 | Index[int] | List[int] | Series[int] | List[str], Series[bool] | np_ndarray_bool | Sequence[bool] | List[str] | str | str_]"
    "tuple[Index[str], str]" is incompatible with "Series[bool]"
    "tuple[Index[str], str]" is incompatible with "np_ndarray_bool"
    "tuple[Index[str], str]" is incompatible with "str"
    "tuple[Index[str], str]" is incompatible with "str_"
      TypeVar "_T_co@Sequence" is covariant
        Type "Index[str] | str" cannot be assigned to type "bool"
          "Index[str]" is incompatible with "bool"
```
This PR fixes that issue by allowing an `Index` to be passed to `setitem` on a DataFrame
