### PR TITLE
Fix annotation for the `parse_dates` argument of the `pandas.read_html` function

### DIFF
--- a/pandas/io/html.pyi
+++ b/pandas/io/html.pyi
@@ -1,6 +1,6 @@
 from pandas._typing import FilePathOrBuffer as FilePathOrBuffer
 from pandas.core.frame import DataFrame as DataFrame
-from typing import Any, Callable, Iterable, List, Mapping, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Union
 
 class _HtmlFrameParser:
     io = ...
@@ -25,7 +25,7 @@ def read_html(
     index_col: Optional[Union[int, Sequence[Any]]] = ...,
     skiprows: Optional[Union[int, Sequence[Any], slice]] = ...,
     attrs: Optional[Mapping[str, str]] = ...,
-    parse_dates: bool = ...,
+    parse_dates: Union[bool, Sequence[Union[int, str, Sequence[Union[int, str]]]], Dict[str, Sequence[Union[int, str]]]] = ...,
     thousands: str = ...,
     encoding: Optional[str] = ...,
     decimal: str = ...,


### PR DESCRIPTION
In the documentation, it's [stated](https://pandas.pydata.org/docs/reference/api/pandas.read_html.html#pandas.read_html) that the usage of the `parse_dates` argument of the `pandas.read_html` function should follow that of the `pandas.read_csv` function. From the [documentation of the `parse_dates` argument of the `pandas.read_csv` function](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html#pandas.read_csv), it can take either a "bool or list of int or names or list of lists or dict".