### PR TITLE
Update parsers.pyi

### DIFF
--- a/pandas/io/parsers.pyi
+++ b/pandas/io/parsers.pyi
@@ -60,7 +60,7 @@ def read_csv(
     low_memory: bool = ...,
     memory_map: bool = ...,
     float_precision: Optional[str] = ...,
-) -> TextFileReader: ...
+) -> DataFrame: ...
 
 @overload
 def read_csv(


### PR DESCRIPTION
Return type of first `read_csv` implementation was wrong. In all my work, it returns a `DataFrame` for example on an `StringIO`.
This solves #87