### PR TITLE
fix Series.mask argument

### DIFF
--- a/pandas/core/series.pyi
+++ b/pandas/core/series.pyi
@@ -605,7 +605,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     ) -> Series[S1]: ...
     def mask(
         self,
-        cond: Union[Series[S1], np.ndarray, Callable],
+        cond: MaskType,
         other: Union[Scalar, Series[S1], DataFrame, Callable] = ...,
         inplace: _bool = ...,
         axis: Optional[SeriesAxisType] = ...,


### PR DESCRIPTION
pylance 2021.8.2

The following code:
```python
import pandas as pd

df = pd.DataFrame([[1, "Y"], [2, "N"]], columns=["n", "flag"])

s = df["flag"]

s2 = df["n"].mask(s == "Y", 0)
```
reports
```
Argument of type "Series[_bool]" cannot be assigned to parameter "cond" of type "Series[Dtype@__getitem__] | ndarray | (*args: Unknown, **kwargs: Unknown) -> Unknown" in function "mask"
  Type "Series[_bool]" cannot be assigned to type "Series[Dtype@__getitem__] | ndarray | (*args: Unknown, **kwargs: Unknown) -> Unknown"
    TypeVar "S1@Series" is invariant
      Type "_bool" cannot be assigned to type "Dtype@__getitem__"
    "Series[_bool]" is incompatible with "ndarray"
    Type "Series[_bool]" cannot be assigned to type "(*args: Unknown, **kwargs: Unknown) -> Unknown"
```

This PR fixes that issue.
