### PR TITLE
pandas: fix .loc setitem with a scalar

### DIFF
--- a/pandas/core/frame.pyi
+++ b/pandas/core/frame.pyi
@@ -70,7 +70,7 @@ class _LocIndexerFrame(_LocIndexer):
     def __setitem__(
         self,
         idx: Union[MaskType, StrLike, Tuple[Union[MaskType, Index, List[str]], Union[MaskType, List[str], str]],],
-        value: Union[float, _np.ndarray, Series[Dtype], DataFrame],
+        value: Union[Scalar, _np.ndarray, Series[Dtype], DataFrame],
     ) -> None: ...
 
 


### PR DESCRIPTION
pylance 2021.8.2

The following code:
```python
import pandas as pd

df = pd.DataFrame([[1, "Y"], [2, "N"]], columns=["n", "f"])

df.loc[df.n >= 1, "f"] = "foo"
```
produces
```
Argument of type "Literal['foo']" cannot be assigned to parameter "value" of type "float | ndarray | Series[Dtype@__setitem__] | DataFrame" in function "__setitem__"
  Type "Literal['foo']" cannot be assigned to type "float | ndarray | Series[Dtype@__setitem__] | DataFrame"
    "Literal['foo']" is incompatible with "float"
    "Literal['foo']" is incompatible with "ndarray"
    "Literal['foo']" is incompatible with "Series[Dtype@__setitem__]"
    "Literal['foo']" is incompatible with "DataFrame"
```

This PR fixes that issue.
