### PR TITLE
matplotlib Patch.__init__ accepts any arguments

### DIFF
--- a/matplotlib/patches.pyi
+++ b/matplotlib/patches.pyi
@@ -4,7 +4,7 @@ from matplotlib.artist import Artist
 
 
 class Patch(Artist):
-    def __init__(self, *args, **kwargs) -> None: ..
+    def __init__(self, *args, **kwargs) -> None: ...
     def __getattr__(self, name: str) -> Any: ...  # incomplete
 
 class Polygon(Patch):

--- a/matplotlib/patches.pyi
+++ b/matplotlib/patches.pyi
@@ -4,6 +4,7 @@ from matplotlib.artist import Artist
 
 
 class Patch(Artist):
+    def __init__(self, *args, **kwargs) -> None: ... # incomplete
     def __getattr__(self, name: str) -> Any: ...  # incomplete
 
 class Polygon(Patch):

--- a/matplotlib/patches.pyi
+++ b/matplotlib/patches.pyi
@@ -4,7 +4,7 @@ from matplotlib.artist import Artist
 
 
 class Patch(Artist):
-    def __init__(self, *args, **kwargs) -> None: ... # incomplete
+    def __init__(self, *args, **kwargs) -> None: ..
     def __getattr__(self, name: str) -> Any: ...  # incomplete
 
 class Polygon(Patch):


### PR DESCRIPTION
Patch and its subclasses accept arguments to `__init__`.
Add `*args` and `**kwargs` to suppress false positive errors when instantiating patches.