### PR TITLE
pandas: allow loc set with scalar arguments

### DIFF
--- a/pandas/core/frame.pyi
+++ b/pandas/core/frame.pyi
@@ -69,7 +69,7 @@ class _LocIndexerFrame(_LocIndexer):
 
     def __setitem__(
         self,
-        idx: Union[MaskType, StrLike, Tuple[Union[MaskType, Index, List[str]], Union[MaskType, List[str], str]],],
+        idx: Union[MaskType, StrLike, Tuple[Union[MaskType, Index, List[Scalar], Scalar], Union[MaskType, List[Scalar], Scalar]],],
         value: Union[Scalar, _np.ndarray, Series[Dtype], DataFrame],
     ) -> None: ...
 


### PR DESCRIPTION
pylance 2021.8.3
```python
import pandas as pd

df = pd.DataFrame([["a", 1], ["b", 2]], columns=["ab", "num"]).set_index("ab")

df.loc["a", "num"] = 10
```
produces
```
Argument of type "tuple[Literal['a'], Literal['num']]" cannot be assigned to parameter "idx" of type "Series[bool] | np_ndarray_bool | Sequence[bool] | str | str_ | Tuple[Series[bool] | np_ndarray_bool | Sequence[bool] | Index[Unknown] | List[str], Series[bool] | np_ndarray_bool | Sequence[bool] | List[str] | str]" in function "__setitem__"
  Type "tuple[Literal['a'], Literal['num']]" cannot be assigned to type "Series[bool] | np_ndarray_bool | Sequence[bool] | str | str_ | Tuple[Series[bool] | np_ndarray_bool | Sequence[bool] | Index[Unknown] | List[str], Series[bool] | np_ndarray_bool | Sequence[bool] | List[str] | str]"
    "tuple[Literal['a'], Literal['num']]" is incompatible with "Series[bool]"
    "tuple[Literal['a'], Literal['num']]" is incompatible with "np_ndarray_bool"
    TypeVar "_T_co@Sequence" is covariant
      "str" is incompatible with "bool"
    "tuple[Literal['a'], Literal['num']]" is incompatible with "str"
    "tuple[Literal['a'], Literal['num']]" is incompatible with "str_"
    Tuple entry 1 is incorrect type
```
This PR fixes that.
