### PR TITLE
Allow Series as argument to pandas.to_datetime

### DIFF
--- a/pandas/core/tools/datetimes.pyi
+++ b/pandas/core/tools/datetimes.pyi
@@ -18,7 +18,7 @@ def should_cache(arg: ArrayConvertible, unique_share: float=..., check_count: Op
 
 @overload
 def to_datetime(
-    arg: DataFrame,
+    arg: Union[DataFrame, Series],
     errors: str = ...,
     dayfirst: bool = ...,
     yearfirst: bool = ...,


### PR DESCRIPTION
pylance V2021.10.0
The following code:
```python
import pandas as pd

s = pd.Series(["10/05/2020", "10/06/2020"])

dt: pd.Series = pd.to_datetime(s)

print(dt)

df = pd.DataFrame([[10, 5, 2020], [10, 6, 2020]], columns=["month", "day", "year"])

dft: pd.Series = pd.to_datetime(df)

print(dft)
```
reports
```
No overloads for "to_datetime" match the provided arguments
  Argument types: (Series[Unknown])
```
on the first assignment (`dt = ...`)  This PR fixes that.
