### PR TITLE
for pandas.loc__setitem__, use Sequence and allow boolean series

### DIFF
--- a/pandas/core/frame.pyi
+++ b/pandas/core/frame.pyi
@@ -73,7 +73,7 @@ class _LocIndexerFrame(_LocIndexer):
 
     def __setitem__(
         self,
-        idx: Union[MaskType, StrLike, Tuple[Union[MaskType, Index, List[Scalar], Scalar], Union[MaskType, List[Scalar], Scalar]],],
+        idx: Union[MaskType, StrLike, Tuple[Union[MaskType, Index, Sequence[Scalar], Series[_bool], Scalar], Union[MaskType, Sequence[Scalar], Scalar]],],
         value: Union[Scalar, _np.ndarray, Series[Dtype], DataFrame],
     ) -> None: ...
 


### PR DESCRIPTION
pylance V2021.10.0
The following code
```python
import numpy as np
import pandas as pd

df = pd.DataFrame([[1, 2], [3, np.nan]], columns=["x", "y"])
s = df["x"] == 1

df2 = df.loc[s, ["x", "y"]]

df.loc[s, ["x", "y"]] = df2 * 2

print(df)
```
reports on the `.loc` line:
```
 Type "tuple[Unknown, list[str]]" cannot be assigned to type "Series[bool] | np_ndarray_bool | Sequence[bool] | str | str_ | Tuple[Series[bool] | np_ndarray_bool | Sequence[bool] | Index[Unknown] | List[Scalar] | str | bytes | date | datetime | timedelta | bool | int | float | complex, Series[bool] | np_ndarray_bool | Sequence[bool] | List[Scalar] | str | bytes | date | datetime | timedelta | bool | int | float | complex]"
    "tuple[Unknown, list[str]]" is incompatible with "Series[bool]"
    "tuple[Unknown, list[str]]" is incompatible with "np_ndarray_bool"
    TypeVar "_T_co@Sequence" is covariant
      Type "Unknown | list[str]" cannot be assigned to type "bool"
        "list[str]" is incompatible with "bool"
    "tuple[Unknown, list[str]]" is incompatible with "str"
    "tuple[Unknown, list[str]]" is incompatible with "str_"
```
This PR addresses that issue in two ways:

1. Use `Series[_bool]` as possible first part of the tuple
2. Use `Sequence[Scalar]` rather than `List[Scalar]` since you can have mixed types in those lists/sequences.

