### PR TITLE
fix arguments to pandas.Series.where()

### DIFF
--- a/pandas/core/series.pyi
+++ b/pandas/core/series.pyi
@@ -598,7 +598,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     ) -> Series: ...
     def where(
         self,
-        cond: Union[Series[S1], Series[S1], np.ndarray],
+        cond: Union[Series[S1], Series[_bool], np.ndarray],
         other = ...,
         inplace: _bool = ...,
         axis: Optional[SeriesAxisType] = ...,


### PR DESCRIPTION
pyright V2021.10.0
The following code:
```python
import pandas as pd

df = pd.DataFrame([[1, 2], [3, 4]], columns=["x", "y"])

df["x"] = df["x"].where(df["y"] == 4, 0)

print(df)
```
reports
```
Argument of type "Series[_bool]" cannot be assigned to parameter "cond" of type "Series[Dtype@__getitem__] | ndarray" in function "where"
  Type "Series[_bool]" cannot be assigned to type "Series[Dtype@__getitem__] | ndarray"
    TypeVar "S1@Series" is invariant
      Type "_bool" cannot be assigned to type "Dtype@__getitem__"
    "Series[_bool]" is incompatible with "ndarray"
```

This PR fixes that.