### PR TITLE
read_csv on_bad_lines and storage_options arguments

### DIFF
--- a/pandas/io/parsers.pyi
+++ b/pandas/io/parsers.pyi
@@ -57,10 +57,12 @@ def read_csv(
     dialect: Optional[str] = ...,
     error_bad_lines: bool = ...,
     warn_bad_lines: bool = ...,
+    on_bad_lines: Literal["error", "warn", "skip"] = "error",
     delim_whitespace: bool = ...,
     low_memory: bool = ...,
     memory_map: bool = ...,
     float_precision: Optional[str] = ...,
+    storage_options: Optional[Dict[str, Any]] = ...,
 ) -> TextFileReader: ...
 @overload
 def read_csv(
@@ -110,10 +112,12 @@ def read_csv(
     dialect: Optional[str] = ...,
     error_bad_lines: bool = ...,
     warn_bad_lines: bool = ...,
+    on_bad_lines: Literal["error", "warn", "skip"] = "error",
     delim_whitespace: bool = ...,
     low_memory: bool = ...,
     memory_map: bool = ...,
     float_precision: Optional[str] = ...,
+    storage_options: Optional[Dict[str, Any]] = ...,
 ) -> TextFileReader: ...
 @overload
 def read_csv(
@@ -163,10 +167,12 @@ def read_csv(
     dialect: Optional[str] = ...,
     error_bad_lines: bool = ...,
     warn_bad_lines: bool = ...,
+    on_bad_lines: Literal["error", "warn", "skip"] = "error",
     delim_whitespace: bool = ...,
     low_memory: bool = ...,
     memory_map: bool = ...,
     float_precision: Optional[str] = ...,
+    storage_options: Optional[Dict[str, Any]] = ...,
 ) -> DataFrame: ...
 @overload
 def read_csv(
@@ -216,10 +222,12 @@ def read_csv(
     dialect: Optional[str] = ...,
     error_bad_lines: bool = ...,
     warn_bad_lines: bool = ...,
+    on_bad_lines: Literal["error", "warn", "skip"] = "error",
     delim_whitespace: bool = ...,
     low_memory: bool = ...,
     memory_map: bool = ...,
     float_precision: Optional[str] = ...,
+    storage_options: Optional[Dict[str, Any]] = ...,
 ) -> TextFileReader: ...
 @overload
 def read_csv(
@@ -268,10 +276,12 @@ def read_csv(
     dialect: Optional[str] = ...,
     error_bad_lines: bool = ...,
     warn_bad_lines: bool = ...,
+    on_bad_lines: Literal["error", "warn", "skip"] = "error",
     delim_whitespace: bool = ...,
     low_memory: bool = ...,
     memory_map: bool = ...,
     float_precision: Optional[str] = ...,
+    storage_options: Optional[Dict[str, Any]] = ...,
 ) -> DataFrame: ...
 @overload
 def read_table(


### PR DESCRIPTION
pylance 2022.1

The following code:
```python
import pandas as pd

df = pd.read_csv(
    "s3://mybucket", on_bad_lines="warn", storage_options={"myawskey": "fake"}
)
```
produces the error:
```
No overloads for "read_csv" match the provided arguments
  Argument types: (Literal['s3://mybucket'], Literal['warn'], dict[str, str])
```

This PR fixes this.  These were changes made in pandas 1.2 and pandas 1.3.
