### PR TITLE
pandas: add dropna argument to DataFrameGroupBy

### DIFF
--- a/pandas/core/frame.pyi
+++ b/pandas/core/frame.pyi
@@ -626,6 +626,7 @@ class DataFrame(NDFrame):
         group_keys: _bool = ...,
         squeeze: _bool = ...,
         observed: _bool = ...,
+        dropna: _bool = ...,
     ) -> DataFrameGroupBy: ...
     def pivot(
         self, index = ..., columns = ..., values = ...,


### PR DESCRIPTION
I believe this fixes #45, which pointed out that [DataFrame.groupby](https://pandas.pydata.org/pandas-docs/dev/reference/api/pandas.DataFrame.groupby.html) now (since pandas v1.1) accepts a `dropna` argument.

This is my first time contributing, and it doesn't look like there's any kind of automated testing I can run to check this or add a new test case (if there is, please let me know!). Instead, I created this tiny snippet in a fresh environment (py3.10, installed pandas, cloned this repo into the dir `typings`). 

```
import pandas as pd

df = pd.DataFrame()
df.groupby("x", dropna=False)
```

Without the change, I get `No parameter named "dropna"` from Pylance, as described in #45. With it, the code type checks as expected.

It's also not clear to me how this change would interact with older versions of pandas. I know this is a hairy subject (I was at the typing meeting a couple weeks ago and only vaguely understood the complexity), but if there's anything for me to do please let me know.