### PR TITLE
Matplotlib marker types

### DIFF
--- a/matplotlib/axes/_axes.pyi
+++ b/matplotlib/axes/_axes.pyi
@@ -667,7 +667,7 @@ class Axes(_AxesBase):
         y: ArrayLike,
         s: Optional[Union[Scalar, ArrayLike]] = ...,
         c: Optional[Union[_ColorLike, Sequence[float], Sequence[_ColorLike]]] = ...,
-        marker: Optional[MarkerStyle] = ...,
+        marker: Optional[Union[MarkerStyle, str]] = ...,
         cmap: Optional[Colormap] = ...,
         norm: Optional[Normalize] = ...,
         vmin: Optional[Scalar] = ...,

--- a/matplotlib/lines.pyi
+++ b/matplotlib/lines.pyi
@@ -4,6 +4,7 @@ from matplotlib._typing import ArrayLike
 from matplotlib.artist import Artist
 from matplotlib.colors import _ColorLike
 from matplotlib.markers import MarkerStyle
+from matplotlib.path import Path
 
 _LineStyle = Union[
     Literal['-', 'solid', '--', 'dashed', '-.', 'dashdot', ':', 'dotted', 'None', '  ', ''],
@@ -18,7 +19,7 @@ class Line2D(Artist):
         linewidth: Optional[float] = ...,
         linestyle: Optional[_LineStyle] = ...,
         color: Optional[_ColorLike] = ...,
-        marker: Optional[MarkerStyle] = ...,
+        marker: Optional[Union[MarkerStyle, Path, str]] = ...,
         markersize: Optional[float] = ...,
         markeredgewidth: Optional[float] = ...,
         markeredgecolor: Optional[_ColorLike] = ...,

--- a/matplotlib/pyplot.pyi
+++ b/matplotlib/pyplot.pyi
@@ -647,7 +647,7 @@ def scatter(
     y: ArrayLike,
     s: Optional[Union[Scalar, ArrayLike]] = ...,
     c: Optional[Union[_ColorLike, Sequence[float], Sequence[_ColorLike]]] = ...,
-    marker: Optional[MarkerStyle] = ...,
+    marker: Optional[Union[MarkerStyle, str]] = ...,
     cmap: Optional[Colormap] = ...,
     norm: Optional[Normalize] = ...,
     vmin: Optional[Scalar] = ...,


### PR DESCRIPTION
My VSCode Pylance told me I couldn't pass `marker="P"` into `matplotlib.pyplot.scatter`.  Am I right in thinking this is the place to correct that?  While I was there I checked where else the `MarkerStyle` was specified in these stubs.

Relevant matplotlib docs:
[Axes.scatter](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.scatter.html?highlight=scatter#matplotlib.axes.Axes.scatter)
[pyplot.scatter](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html?highlight=scatter#matplotlib.pyplot.scatter)
[Line2D](https://matplotlib.org/stable/api/_as_gen/matplotlib.lines.Line2D.html?highlight=line2d#matplotlib.lines.Line2D)
