### PR TITLE
fix read_csv to work with different overloads

### DIFF
--- a/pandas/io/parsers.pyi
+++ b/pandas/io/parsers.pyi
@@ -12,6 +12,7 @@ else:
 @overload
 def read_csv(
     reader: FilePathOrBuffer,
+    *,
     sep: str = ...,
     delimiter: Optional[str] = ...,
     header: Union[int, Sequence[int], str, Literal["infer"]] = ...,
@@ -41,7 +42,7 @@ def read_csv(
     date_parser: Optional[Callable] = ...,
     dayfirst: bool = ...,
     cache_dates: bool = ...,
-    iterator: bool = ...,
+    iterator: Literal[True],
     chunksize: Optional[int] = ...,
     compression: Optional[Union[str, Literal["infer", "gzip", "bz2", "zip", "xz"]]] = ...,
     thousands: Optional[str] = ...,
@@ -284,6 +285,7 @@ def read_csv(
 @overload
 def read_table(
     reader: FilePathOrBuffer,
+    *,
     sep: str = ...,
     delimiter: Optional[str] = ...,
     header: Union[int, Sequence[int], str, Literal["infer"]] = ...,


### PR DESCRIPTION
pylance 2022.2.0

The following code reports errors incorrectly:

```python
from io import StringIO
import pandas as pd
from pandas.io.parsers import TextFileReader

dio = StringIO("a,b\n 1,2\n 3,4\n")

df: pd.DataFrame = pd.read_csv(dio)

print(df)

dio.seek(0)
tr: pd.DataFrame = pd.read_csv(dio)

dio.seek(0)
tr2: TextFileReader = pd.read_csv(dio, iterator=True)

dio.seek(0)
tr3: pd.DataFrame = pd.read_csv(dio, iterator=False)

dio.seek(0)
tr5: TextFileReader = pd.read_csv(dio, chunksize=10)

dio.seek(0)
tr6: pd.DataFrame = pd.read_csv(dio, chunksize=None)

dio.seek(0)
tr7: pd.DataFrame = pd.read_csv(dio, header="infer")

dio.seek(0)
tr8: TextFileReader = pd.read_csv(dio, header="infer", iterator=True)


ftr1: TextFileReader = pd.read_csv("hey.csv")
ftr2: pd.DataFrame = pd.read_csv("hey.csv", iterator=True)
ftr3: TextFileReader = pd.read_csv("hey.csv", iterator=False)
ftr5: pd.DataFrame = pd.read_csv("hey.csv", chunksize=10)
ftr6: TextFileReader = pd.read_csv("he.csv", chunksize=None)
ftr7: TextFileReader = pd.read_csv("hey.csv", header="infer")
ftr8: pd.DataFrame = pd.read_csv("hey.csv", header="infer", iterator=True)
```

e.g., on the first assignment of `tr1`:
```
Expression of type "TextFileReader" cannot be assigned to declared type "DataFrame"
  "TextFileReader" is incompatible with "DataFrame"
```

The test code above is set up to pass on all the assignments to `tr#` and fail on the assignments to `ftr#`

This was all working with PR #87 and I think #129 messed it up (@gramster)
