### PR TITLE
fix arguments to pandas pd.merge

### DIFF
--- a/pandas/core/reshape/merge.pyi
+++ b/pandas/core/reshape/merge.pyi
@@ -3,7 +3,7 @@ from pandas import DataFrame as DataFrame, Series as Series
 from pandas._typing import Label
 from typing import Optional, Sequence, Union
 
-def merge(left: DataFrame,
+def merge(left: DataFrame|Series,
           right: DataFrame|Series,
           how: str = ...,
           on: Optional[Union[Label, Sequence]] = ...,


### PR DESCRIPTION
pylance 2022.2.0

The following code:
```python
import pandas as pd

df1 = pd.DataFrame([["a", 1], ["b", 2]], columns=["let", "num"]).set_index("let")

s2 = df1["num"]

res = pd.merge(s2, df1, left_index=True, right_index=True)

print(res)
```
reports
```
Argument of type "Series[S1@__getitem__]" cannot be assigned to parameter "left" of type "DataFrame" in function "merge"
  "Series[S1@__getitem__]" is incompatible with "DataFrame"
```

This PR fixes that issue.  Note it was previously fixed in #61 and then broken in #129 .



