### PR TITLE
pandas - fix series.loc with multiindex slice

### DIFF
--- a/pandas/core/series.pyi
+++ b/pandas/core/series.pyi
@@ -69,7 +69,7 @@ class _LocIndexerSeries(_LocIndexer, Generic[S1]):
     @overload
     def __getitem__(
         self,
-        idx: Union[MaskType, Index, Sequence[str], slice],
+        idx: Union[MaskType, Index, Sequence[str], slice, Tuple[int, str, slice], ...]],
     ) -> Series[S1]: ...
     @overload
     def __getitem__(

--- a/tests/pandas/test_series.py
+++ b/tests/pandas/test_series.py
@@ -80,6 +80,11 @@ def test_types_loc_at() -> None:
     s2.loc[1]
     s2.at[1]
 
+def test_multiindex_loc() -> None:
+    s = pd.Series([1, 2, 3], 
+                  index=pd.MultiIndex.from_product([[1, 2], ["a", "b"]]))
+    s.loc[1, :]
+
 
 def test_types_boolean_indexing() -> None:
     s = pd.Series([0, 1, 2])


### PR DESCRIPTION
pylance 2022.2.0

Following code:
```python
import pandas as pd

from typing import Union, Tuple

df = pd.DataFrame({"x": [1, 2, 3], "y": ["a", "b", "c"], "z": [10, 20, 30]}).set
_index(
    ["x", "y"]
)

s = df["z"]

s2 = s.loc[1, :]

s3 = pd.Series([10, 20, 30], index=df.index)

s4 = s3.loc[2, :]
```

produces
```
Argument of type "tuple[Literal[1], slice]" cannot be assigned to parameter "idx" of type "int | str" in function "__getitem__"
  Type "tuple[Literal[2], slice]" cannot be assigned to type "int | str"
    "tuple[Literal[2], slice]" is incompatible with "int"
    "tuple[Literal[2], slice]" is incompatible with "str"
Argument of type "tuple[Literal[2], slice]" cannot be assigned to parameter "idx" of type "int | str" in function "__getitem__"
  Type "tuple[Literal[2], slice]" cannot be assigned to type "int | str"
    "tuple[Literal[2], slice]" is incompatible with "int"
    "tuple[Literal[2], slice]" is incompatible with "str"
```

This PR fixes that, and it adds a test to verify.

