### PR TITLE
matplotlib.pyplot.subplots: Add multi-plot overloads

### DIFF
--- a/matplotlib/pyplot.pyi
+++ b/matplotlib/pyplot.pyi
@@ -774,16 +774,44 @@ def subplot_mosaic(layout: Union[ArrayLike, str], *, subplot_kw: Optional[Dict[s
 
 def subplot_tool(targetfig: Optional[Figure]) -> SubplotTool: ...
 
+@overload
+def subplots(
+    nrows: Literal[1] = ...,
+    ncols: Literal[1] = ...,
+    *,
+    sharex: Union[bool, Literal["none", "all", "row", "col"]] = ...,
+    sharey: Union[bool, Literal["none", "all", "row", "col"]] = ...,
+    squeeze: Literal[True] = ...,
+    subplot_kw: Optional[Dict[Any, Any]] = ...,
+    gridspec_kw: Optional[Dict[Any, Any]] = ...,
+    **fig_kw: Any
+) -> Tuple[Figure, Axes]: ...
+
+@overload
 def subplots(
     nrows: int = ...,
     ncols: int = ...,
+    *,
+    sharex: Union[bool, Literal["none", "all", "row", "col"]] = ...,
+    sharey: Union[bool, Literal["none", "all", "row", "col"]] = ...,
+    squeeze: Literal[False],
+    subplot_kw: Optional[Dict[Any, Any]] = ...,
+    gridspec_kw: Optional[Dict[Any, Any]] = ...,
+    **fig_kw: Any
+) -> Tuple[Figure, ndarray]: ...
+
+@overload
+def subplots(
+    nrows: int = ...,
+    ncols: int = ...,
+    *,
     sharex: Union[bool, Literal["none", "all", "row", "col"]] = ...,
     sharey: Union[bool, Literal["none", "all", "row", "col"]] = ...,
     squeeze: bool = ...,
     subplot_kw: Optional[Dict[Any, Any]] = ...,
     gridspec_kw: Optional[Dict[Any, Any]] = ...,
     **fig_kw: Any
-) -> Tuple[Figure, Axes]: ...
+) -> Tuple[Figure, Union[Axes, ndarray]]: ...
 
 def subplots_adjust(left: Optional[float] = ..., bottom: Optional[float] = ..., right: Optional[float] = ..., top: Optional[float] = ..., wspace: Optional[float] = ..., hspace: Optional[float] = ...) -> None: ...
 


### PR DESCRIPTION
Adds overloads to plt.subplots().

The overloads handle, in order:
 1. `plt.subplots(nrows=1, nrows=2, squeeze=True)` -> single `Axes` (the default case)
 2. `plt.subplots(squeeze=False) -> ndarray` (explicit array return, as keyword)
 3. `plt.subplots(nrows, ncols, sharex, sharey, False) -> ndarray` (explicit array return, as positional)
 4. `plot.subplots(nrows, ncols) -> ndarray | Axes` (not knowable at compile time)

The current return value is incorrect, and a big stumbling block when dealing with multi-Axes plots.