### PR TITLE
pandas: fix iloc to accept list

### DIFF
--- a/partial/pandas/_typing.pyi
+++ b/partial/pandas/_typing.pyi
@@ -104,7 +104,7 @@ np_ndarray_int64 = npt.NDArray[np.int64]
 np_ndarray_bool = npt.NDArray[np.bool_]
 np_ndarray_str = npt.NDArray[np.str_]
 IndexType = Union[slice, np_ndarray_int64, Index, List[int], Series[int]]
-MaskType = Union[Series[bool], np_ndarray_bool, Sequence[bool]]
+MaskType = Union[Series[bool], np_ndarray_bool, List[bool]]
 # Scratch types for generics
 S1 = TypeVar(
     "S1",

--- a/partial/pandas/core/frame.pyi
+++ b/partial/pandas/core/frame.pyi
@@ -81,7 +81,9 @@ class _iLocIndexerFrame(_iLocIndexer):
     @overload
     def __getitem__(self, idx: Tuple[int, Union[IndexType, MaskType]]) -> Series: ...
     @overload
-    def __getitem__(self, idx: Tuple[Union[IndexType, MaskType], Union[IndexType, MaskType]]) -> DataFrame: ...
+    def __getitem__(self, idx: Union[IndexType, MaskType,
+                                     Tuple[Union[IndexType, MaskType], 
+                                           Union[IndexType, MaskType]]]) -> DataFrame: ...
     def __setitem__(
         self,
         idx: Union[

--- a/tests/pandas/test_frame.py
+++ b/tests/pandas/test_frame.py
@@ -913,3 +913,8 @@ def test_getmultiindex_columns() -> None:
 def test_frame_getitem_isin() -> None:
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5]}, index=[1, 2, 3, 4, 5])
     check_dataframe_result(df[df.index.isin([1, 3, 5])])
+
+
+def test_iloc_list() -> None:
+    df = pd.DataFrame({"x": [i for i in range(10)], "y": [i * 10 for i in range(10)]}, index=[100 + i for i in range(10)])
+    cdf: pd.DataFrame = pd.concat([df.iloc[[i * 2 for i in range(5)]]])


### PR DESCRIPTION
Allow `DataFrame.iloc` to accept lists, etc. that produce a `DataFrame`
