### PR TITLE
Impove pyplot in matplotlib

### DIFF
--- a/matplotlib/pyplot.pyi
+++ b/matplotlib/pyplot.pyi
@@ -789,16 +789,29 @@ def subplots(
 
 @overload
 def subplots(
-    nrows: int = ...,
+    nrows: Literal[1] = ...,
     ncols: int = ...,
     *,
     sharex: Union[bool, Literal["none", "all", "row", "col"]] = ...,
     sharey: Union[bool, Literal["none", "all", "row", "col"]] = ...,
-    squeeze: Literal[False],
+    squeeze: Literal[True] = ...,
     subplot_kw: Optional[Dict[Any, Any]] = ...,
     gridspec_kw: Optional[Dict[Any, Any]] = ...,
     **fig_kw: Any
-) -> Tuple[Figure, ndarray]: ...
+) -> Tuple[Figure, Sequence[Axes]]: ...
+
+@overload
+def subplots(
+    nrows: int = ...,
+    ncols: Literal[1] = ...,
+    *,
+    sharex: Union[bool, Literal["none", "all", "row", "col"]] = ...,
+    sharey: Union[bool, Literal["none", "all", "row", "col"]] = ...,
+    squeeze: Literal[True] = ...,
+    subplot_kw: Optional[Dict[Any, Any]] = ...,
+    gridspec_kw: Optional[Dict[Any, Any]] = ...,
+    **fig_kw: Any
+) -> Tuple[Figure, Sequence[Axes]]: ...
 
 @overload
 def subplots(
@@ -811,7 +824,7 @@ def subplots(
     subplot_kw: Optional[Dict[Any, Any]] = ...,
     gridspec_kw: Optional[Dict[Any, Any]] = ...,
     **fig_kw: Any
-) -> Tuple[Figure, Union[Axes, ndarray]]: ...
+) -> Tuple[Figure, Sequence[Sequence[Axes]]]: ...
 
 def subplots_adjust(left: Optional[float] = ..., bottom: Optional[float] = ..., right: Optional[float] = ..., top: Optional[float] = ..., wspace: Optional[float] = ..., hspace: Optional[float] = ...) -> None: ...
 

--- a/matplotlib/pyplot.pyi
+++ b/matplotlib/pyplot.pyi
@@ -38,7 +38,7 @@ from matplotlib.colorbar import Colorbar
 from matplotlib.colors import Normalize as Normalize, _ColorLike  # undocumented
 from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
 from matplotlib.contour import ContourSet, QuadContourSet
-from matplotlib.figure import Figure
+from matplotlib.figure import Figure as Figure # undocumented
 from matplotlib.image import AxesImage, FigureImage
 from matplotlib.legend import Legend
 from matplotlib.lines import Line2D as Line2D  # undocumented


### PR DESCRIPTION
- People can use `plt.Figure` the same way as `plt.Axes` for type annotation
- Explicit overload for `plt.subplots` for the returned `Axes` or `Sequence[Axes]`  or `Sequence[Sequence[Axes]]` based on dimension
    - Ideally it should be a NDArray with element type Axes, but I don't know how to make it work... 
    - Fix https://github.com/microsoft/python-type-stubs/issues/216