### PR TITLE
adding missing `__getitem__` to matplot _AxesBase

### DIFF
--- a/matplotlib/axes/_base.pyi
+++ b/matplotlib/axes/_base.pyi
@@ -3,6 +3,7 @@ from typing import Any
 
 class _AxesBase:
     def __getattr__(self, name: str) -> Any: ...  # incomplete
+    def __getitem__(self, key): ... # incomplete
 
 
 def __getattr__(name: str) -> Any: ...  # incomplete


### PR DESCRIPTION
in the code the `__getitem__` call is  really on the parent class
https://github.com/matplotlib/matplotlib/blob/1efc391434812f0f24392ca4a45c5cd846f46862/lib/matplotlib/axes/_base.py#L1378

https://github.com/microsoft/pylance-release/issues/3192