### PR TITLE
Remove duplicate entry in upstreamed libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ and are no longer maintained here:
 - PIL
 - retry
 - slugify
-- pandas (see https://github.com/pandas-dev/pandas-stubs; please open pandas stub issues there)
-
 
 # Trademarks
 


### PR DESCRIPTION
Seems it was just from a fault merge.