### PR TITLE
Update matplot subplots stubs

### DIFF
--- a/matplotlib/pyplot.pyi
+++ b/matplotlib/pyplot.pyi
@@ -126,7 +126,7 @@ def subplots(
 @overload
 def subplots(
     nrows: Literal[1],
-    ncols: Literal[1],
+    ncols: Literal[1] = ...,
     *,
     sharex: bool | Literal["none", "all", "row", "col"] = ...,
     sharey: bool | Literal["none", "all", "row", "col"] = ...,


### PR DESCRIPTION
https://github.com/microsoft/pylance-release/issues/3482

Expect `plt.subplots(1)` to return just a single Axes

```python
from matplotlib import pyplot as plt
fig, ax = plt.subplots(1)
ax.get_xaxis().set_ticks([])
```
