### PR TITLE
Support to `subplots` receiving no argument

### DIFF
--- a/matplotlib/figure.pyi
+++ b/matplotlib/figure.pyi
@@ -112,8 +112,8 @@ class FigureBase(Artist):
     @overload
     def subplots(
         self,
-        nrows: int = ...,
-        ncols: int = ...,
+        nrows: int,
+        ncols: int,
         *,
         squeeze: bool = ...,
         sharex: bool | Literal["none", "all", "row", "col"] = ...,


### PR DESCRIPTION
Modification to support situation when `subplots` receives no argument and returns a singe `Axes`. 

The third `@overload` should be used, but it was using the 4th overload due to the defaults in `nrows` and `ncols` when `squeeze` is not given. This PR corrects that.