### PR TITLE
adding sklearn overload for fetch_openml

### DIFF
--- a/sklearn/datasets/_openml.pyi
+++ b/sklearn/datasets/_openml.pyi
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, overload, Literal
 from warnings import warn
 from contextlib import closing as closing
 from tempfile import TemporaryDirectory as TemporaryDirectory
@@ -35,6 +35,7 @@ class OpenMLError(ValueError):
     ...
 
 
+@overload
 def fetch_openml(
     name: Optional[str] = None,
     *,
@@ -43,7 +44,23 @@ def fetch_openml(
     data_home: Optional[str] = None,
     target_column: Optional[Union[str, List]] = "default-target",
     cache: bool = True,
-    return_X_y: bool = False,
+    return_X_y : Literal[False] = ...,
+    as_frame: Union[str, bool] = "auto",
+    n_retries: int = 3,
+    delay: float = 1.0,
+    parser: Optional[str] = "warn",
+) -> Bunch:
+    ...
+@overload
+def fetch_openml(
+    name: Optional[str] = None,
+    *,
+    version: Union[str, int] = "active",
+    data_id: Optional[int] = None,
+    data_home: Optional[str] = None,
+    target_column: Optional[Union[str, List]] = "default-target",
+    cache: bool = True,
+    return_X_y : Literal[True] = ...,
     as_frame: Union[str, bool] = "auto",
     n_retries: int = 3,
     delay: float = 1.0,


### PR DESCRIPTION
```python
from sklearn.datasets import fetch_openml
survey = fetch_openml(data_id=534, as_frame=True)
```

the docstring  ` (data, target) : tuple if ``return_X_y`` is True`
```
Returns
    -------
    data : :class:`~sklearn.utils.Bunch`
        Dictionary-like object, with the following attributes.

        data : np.array, scipy.sparse.csr_matrix of floats, or pandas DataFrame
            The feature matrix. Categorical features are encoded as ordinals.
        target : np.array, pandas Series or DataFrame
            The regression target or classification labels, if applicable.
            Dtype is float if numeric, and object if categorical. If
            ``as_frame`` is True, ``target`` is a pandas object.
        DESCR : str
            The full description of the dataset.
        feature_names : list
            The names of the dataset columns.
        target_names: list
            The names of the target columns.

        .. versionadded:: 0.22

        categories : dict or None
            Maps each categorical feature name to a list of values, such
            that the value encoded as i is ith in the list. If ``as_frame``
            is True, this is None.
        details : dict
            More metadata from OpenML.
        frame : pandas DataFrame
            Only present when `as_frame=True`. DataFrame with ``data`` and
            ``target``.

    (data, target) : tuple if ``return_X_y`` is True

        .. note:: EXPERIMENTAL

            This interface is **experimental** and subsequent releases may
            change attributes without notice (although there should only be
            minor changes to ``data`` and ``target``).

        Missing values in the 'data' are represented as NaN's. Missing values
        in 'target' are represented as NaN's (numerical target) or None
        (categorical target).

```