### PR TITLE
Import `TypeAlias` from `typing_extensions`

### DIFF
--- a/sklearn/_typing.pyi
+++ b/sklearn/_typing.pyi
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from .base import BaseEstimator, ClassifierMixin, RegressorMixin
 from scipy.sparse import spmatrix
-from typing import TypeAlias
+from typing_extensions import TypeAlias
 
 
 Decimal: TypeAlias = decimal.Decimal


### PR DESCRIPTION
When I run pyright with
```
pythonVersion = "3.8"
```
it gets confused about the type aliases because it apparently doesn't know about `typing.TypeAlias`. (Not sure whether this should be considered a bug in pyright.)