### PR TITLE
Remove import from same file

### DIFF
--- a/matplotlib/widgets.pyi
+++ b/matplotlib/widgets.pyi
@@ -1,6 +1,5 @@
 from matplotlib.axes._axes import Axes
 from numpy.typing import ArrayLike
-from matplotlib.widgets import Slider
 from typing import (
     Dict,
     List,


### PR DESCRIPTION
Fixes https://github.com/microsoft/python-type-stubs/issues/268

I did a quick scan of the other matplotlib stub files and didn't see any other issues of this sort.