### PR TITLE
Accept 'tick_labels' param for 'boxplot' (matplotlib 3.9)

### DIFF
--- a/stubs/matplotlib/axes/_axes.pyi
+++ b/stubs/matplotlib/axes/_axes.pyi
@@ -254,7 +254,8 @@ class Axes(_AxesBase):
         showbox=...,
         showfliers=...,
         boxprops=...,
-        labels: Sequence = ...,
+        labels: Sequence = ...,  # deprecated
+        tick_labels: Sequence = ...,
         flierprops=...,
         medianprops=...,
         meanprops=...,

--- a/stubs/matplotlib/axes/_axes.pyi
+++ b/stubs/matplotlib/axes/_axes.pyi
@@ -255,7 +255,7 @@ class Axes(_AxesBase):
         showfliers=...,
         boxprops=...,
         labels: Sequence = ...,  # deprecated
-        tick_labels: Sequence = ...,
+        tick_labels: Sequence[str] = ...,
         flierprops=...,
         medianprops=...,
         meanprops=...,

--- a/stubs/matplotlib/pyplot.pyi
+++ b/stubs/matplotlib/pyplot.pyi
@@ -358,7 +358,7 @@ def boxplot(
     showfliers=...,
     boxprops=...,
     labels: Sequence = ...,  # deprecated
-    tick_labels: Sequence = ...,
+    tick_labels: Sequence[str] = ...,
     flierprops=...,
     medianprops=...,
     meanprops=...,

--- a/stubs/matplotlib/pyplot.pyi
+++ b/stubs/matplotlib/pyplot.pyi
@@ -357,7 +357,8 @@ def boxplot(
     showbox=...,
     showfliers=...,
     boxprops=...,
-    labels: Sequence = ...,
+    labels: Sequence = ...,  # deprecated
+    tick_labels: Sequence = ...,
     flierprops=...,
     medianprops=...,
     meanprops=...,


### PR DESCRIPTION
The `labels` parameter for [`boxplot()`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.boxplot.html) has been [deprecated in matplotlib 3.9.0](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#boxplot-tick-labels)

> ### boxplot tick labels
> The parameter `labels` has been renamed to `tick_labels` for clarity and consistency with [bar](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.bar.html#matplotlib.axes.Axes.bar).

instead `tick_labels` should be used:

> **tick_labels:** list of str, optional
> The tick labels of each boxplot. Ticks are always placed at the box positions. If `tick_labels` is given, the ticks are labelled accordingly. Otherwise, they keep their numeric values.
> >   Changed in version 3.9: Renamed from `labels`, which is deprecated since 3.9 and will be removed in 3.11.
