### PR TITLE
Add reason to ignore mypy assert-type in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,11 +151,14 @@ disallow_untyped_defs = false
 disable_error_code = [
     # Not all imports in these stubs are gonna be typed
     "import-untyped",
+    # mypy's overload implementation differs from pyright
+    # `assert-type` issues is tests mostly comme from checking overloads
+    # Since this project is specific to Pylance, just ignore them
+    "assert-type",
     # TODO
     "valid-type", # 967 errors in 115 files
     "override", # 790 errors in 220 files
     "assignment", # 773 errors in 172 files
     "misc", # 692 errors in 132 files
     "attr-defined", # 202 errors in 75 files
-    "assert-type", # 6 errors in 1 file
 ]

--- a/stubs/sklearn/preprocessing/_data.pyi
+++ b/stubs/sklearn/preprocessing/_data.pyi
@@ -221,7 +221,7 @@ def normalize(
     *,
     axis: int = 1,
     copy: bool = True,
-    return_norm: Literal[False] = ...,
+    return_norm: Literal[False] = False,
 ) -> csr_matrix: ...
 @overload
 def normalize(
@@ -239,7 +239,7 @@ def normalize(
     *,
     axis: int = 1,
     copy: bool = True,
-    return_norm: Literal[False] = ...,
+    return_norm: Literal[False] = False,
 ) -> ndarray: ...
 def normalize(
     X: MatrixLike | ArrayLike,


### PR DESCRIPTION
Not only can overloads differ between pyright and mypy, but in this case, mypy was completely wrong in `tests/sklearn/preprocessing_tests.py`.

`assert_type` is only used in static type tests, and those tests are mostly used to confirm complex type results (from overloads and typevars). At that point may as well just disable it.

I don't see this as an issue in the idea of "porting to typeshed" either, because typeshed already deals with typecheckers differences in tests. And would have to adapt to its repo.