### PR TITLE
Add missing `contextlib.contextmanager` to `sklearn.config_context`

### DIFF
--- a/stubs/sklearn/_config.pyi
+++ b/stubs/sklearn/_config.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Generator
-from contextlib import contextmanager as contextmanager
+from contextlib import contextmanager
 from typing import Literal
 
 from ._typing import Int

--- a/stubs/sklearn/_config.pyi
+++ b/stubs/sklearn/_config.pyi
@@ -1,4 +1,5 @@
-from collections.abc import Iterator
+from collections.abc import Generator
+from contextlib import contextmanager as contextmanager
 from typing import Literal
 
 from ._typing import Int
@@ -19,6 +20,7 @@ def set_config(
     enable_metadata_routing: None | bool = None,
     skip_parameter_validation: None | bool = None,
 ) -> None: ...
+@contextmanager
 def config_context(
     *,
     assume_finite: None | bool = None,
@@ -31,4 +33,4 @@ def config_context(
     transform_output: None | str = None,
     enable_metadata_routing: None | bool = None,
     skip_parameter_validation: None | bool = None,
-) -> Iterator[None]: ...
+) -> Generator[None, None, None]: ...


### PR DESCRIPTION
The current [type hints](https://github.com/microsoft/python-type-stubs/blob/692c37c3969d22612b295ddf7e7af5907204a386/stubs/sklearn/_config.pyi#L22) for the `sklearn.config_context` context manager [is missing](https://github.com/scikit-learn/scikit-learn/blob/d86a1dfe450ab8b6988e6acbb83a12bc581f0e0b/sklearn/_config.py#L247) the `contextlib.contextmanager` decorator.

This PR also updates the return value to using `Generator` hint since `Iterator` [is deprecated ](https://github.com/python/typeshed/blob/bd18cc640cba4dadc51ac9a5157b79ff6adf5de3/stdlib/contextlib.pyi#L92).

